### PR TITLE
section 1 : 로그 추적기 적용

### DIFF
--- a/src/main/java/hello/advanced/app/v0/OrderControllerV0.java
+++ b/src/main/java/hello/advanced/app/v0/OrderControllerV0.java
@@ -1,4 +1,4 @@
-package hello.advanced.v0;
+package hello.advanced.app.v0;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/hello/advanced/app/v0/OrderRepositoryV0.java
+++ b/src/main/java/hello/advanced/app/v0/OrderRepositoryV0.java
@@ -1,4 +1,4 @@
-package hello.advanced.v0;
+package hello.advanced.app.v0;
 
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/hello/advanced/app/v0/OrderServiceV0.java
+++ b/src/main/java/hello/advanced/app/v0/OrderServiceV0.java
@@ -1,4 +1,4 @@
-package hello.advanced.v0;
+package hello.advanced.app.v0;
 
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/hello/advanced/app/v1/OrderControllerV1.java
+++ b/src/main/java/hello/advanced/app/v1/OrderControllerV1.java
@@ -1,0 +1,32 @@
+package hello.advanced.app.v1;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hello.advanced.trace.TraceStatus;
+import hello.advanced.trace.hellotrace.HelloTraceV1;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderControllerV1 {
+
+	private final OrderServiceV1 orderServiceV1;
+
+	private final HelloTraceV1 helloTraceV1;
+
+
+	@GetMapping("/v1/request")
+	public String request(String itemId) {
+		TraceStatus status = null;
+		try {
+			status = helloTraceV1.begin("OrderController.request()");
+			orderServiceV1.orderItem(itemId);
+			helloTraceV1.end(status);
+			return "ok";
+		}catch (Exception e) {
+			helloTraceV1.exception(status, e);
+			throw e; // 예외를 꼭 다시 던져주어야 한다.
+		}
+	}
+}

--- a/src/main/java/hello/advanced/app/v1/OrderRepositoryV1.java
+++ b/src/main/java/hello/advanced/app/v1/OrderRepositoryV1.java
@@ -1,0 +1,40 @@
+package hello.advanced.app.v1;
+
+import org.springframework.stereotype.Repository;
+
+import hello.advanced.trace.TraceStatus;
+import hello.advanced.trace.hellotrace.HelloTraceV1;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryV1 {
+
+	private final HelloTraceV1 helloTraceV1;
+
+	public void save(String itemId) {
+
+		TraceStatus status = null;
+		try {
+			status = helloTraceV1.begin("OrderRepository.save()");
+			if(itemId.equals("ex")) {
+				throw new IllegalStateException("예외 발생");
+			}
+			sleep(1000);
+			helloTraceV1.end(status);
+		}catch (Exception e) {
+			helloTraceV1.exception(status, e);
+			throw e; // 예외를 꼭 다시 던져주어야 한다.
+		}
+
+		// 저장 로직
+	}
+
+	private void sleep(int millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/hello/advanced/app/v1/OrderServiceV1.java
+++ b/src/main/java/hello/advanced/app/v1/OrderServiceV1.java
@@ -1,0 +1,29 @@
+package hello.advanced.app.v1;
+
+import org.springframework.stereotype.Service;
+
+import hello.advanced.trace.TraceStatus;
+import hello.advanced.trace.hellotrace.HelloTraceV1;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceV1 {
+
+	private final OrderRepositoryV1 orderRepositoryV1;
+
+	private final HelloTraceV1 helloTraceV1;
+
+	public void orderItem(String itemId) {
+		TraceStatus status = null;
+		try {
+			status = helloTraceV1.begin("OrderService.orderItem()");
+			orderRepositoryV1.save(itemId);
+			helloTraceV1.end(status);
+		}catch (Exception e) {
+			helloTraceV1.exception(status, e);
+			throw e; // 예외를 꼭 다시 던져주어야 한다.
+		}
+	}
+
+}

--- a/src/main/java/hello/advanced/app/v2/OrderControllerV2.java
+++ b/src/main/java/hello/advanced/app/v2/OrderControllerV2.java
@@ -1,0 +1,32 @@
+package hello.advanced.app.v2;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hello.advanced.trace.TraceStatus;
+import hello.advanced.trace.hellotrace.HelloTraceV2;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderControllerV2 {
+
+	private final OrderServiceV2 orderServiceV2;
+
+	private final HelloTraceV2 helloTraceV2;
+
+
+	@GetMapping("/v2/request")
+	public String request(String itemId) {
+		TraceStatus status = null;
+		try {
+			status = helloTraceV2.begin("OrderController.request()");
+			orderServiceV2.orderItem(itemId, status.getTraceId());
+			helloTraceV2.end(status);
+			return "ok";
+		}catch (Exception e) {
+			helloTraceV2.exception(status, e);
+			throw e; // 예외를 꼭 다시 던져주어야 한다.
+		}
+	}
+}

--- a/src/main/java/hello/advanced/app/v2/OrderRepositoryV2.java
+++ b/src/main/java/hello/advanced/app/v2/OrderRepositoryV2.java
@@ -1,0 +1,41 @@
+package hello.advanced.app.v2;
+
+import org.springframework.stereotype.Repository;
+
+import hello.advanced.trace.TraceId;
+import hello.advanced.trace.TraceStatus;
+import hello.advanced.trace.hellotrace.HelloTraceV2;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryV2 {
+
+	private final HelloTraceV2 helloTraceV2;
+
+	public void save(String itemId, TraceId traceId) {
+
+		TraceStatus status = null;
+		try {
+			status = helloTraceV2.beginSync(traceId,"OrderRepository.save()");
+			if(itemId.equals("ex")) {
+				throw new IllegalStateException("예외 발생");
+			}
+			sleep(1000);
+			helloTraceV2.end(status);
+		}catch (Exception e) {
+			helloTraceV2.exception(status, e);
+			throw e; // 예외를 꼭 다시 던져주어야 한다.
+		}
+
+		// 저장 로직
+	}
+
+	private void sleep(int millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/hello/advanced/app/v2/OrderServiceV2.java
+++ b/src/main/java/hello/advanced/app/v2/OrderServiceV2.java
@@ -1,0 +1,30 @@
+package hello.advanced.app.v2;
+
+import org.springframework.stereotype.Service;
+
+import hello.advanced.trace.TraceId;
+import hello.advanced.trace.TraceStatus;
+import hello.advanced.trace.hellotrace.HelloTraceV2;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceV2 {
+
+	private final OrderRepositoryV2 orderRepositoryV2;
+
+	private final HelloTraceV2 helloTraceV2;
+
+	public void orderItem(String itemId, TraceId traceId) {
+		TraceStatus status = null;
+		try {
+			status = helloTraceV2.beginSync(traceId,"OrderService.orderItem()");
+			orderRepositoryV2.save(itemId, status.getTraceId());
+			helloTraceV2.end(status);
+		}catch (Exception e) {
+			helloTraceV2.exception(status, e);
+			throw e; // 예외를 꼭 다시 던져주어야 한다.
+		}
+	}
+
+}

--- a/src/main/java/hello/advanced/trace/TraceId.java
+++ b/src/main/java/hello/advanced/trace/TraceId.java
@@ -1,0 +1,38 @@
+package hello.advanced.trace;
+
+import java.util.UUID;
+
+import lombok.Getter;
+
+@Getter
+public class TraceId {
+
+
+	private String id;
+	private int level;
+
+	public TraceId() {
+		this.id = createId();
+		this.level = 0;
+	}
+
+	private TraceId(String id, int level) {
+		this.id = id;
+		this.level = level;
+	}
+
+	private String createId() {
+		return UUID.randomUUID().toString().substring(0, 8);
+	}
+
+	public TraceId createNextId() {
+		return new TraceId(id, level + 1);
+	}
+	public TraceId createPreviousNextId() {
+		return new TraceId(id, level - 1);
+	}
+
+	public boolean isFirstLevel() {
+		return level == 0;
+	}
+}

--- a/src/main/java/hello/advanced/trace/TraceStatus.java
+++ b/src/main/java/hello/advanced/trace/TraceStatus.java
@@ -1,0 +1,17 @@
+package hello.advanced.trace;
+
+import lombok.Getter;
+
+@Getter
+public class TraceStatus {
+
+	private final TraceId traceId;
+	private final Long startTimeMs;
+	private final String message;
+
+	public TraceStatus(TraceId traceId, Long startTimeMs, String message) {
+		this.traceId = traceId;
+		this.startTimeMs = startTimeMs;
+		this.message = message;
+	}
+}

--- a/src/main/java/hello/advanced/trace/hellotrace/HelloTraceV1.java
+++ b/src/main/java/hello/advanced/trace/hellotrace/HelloTraceV1.java
@@ -1,0 +1,49 @@
+package hello.advanced.trace.hellotrace;
+
+import org.springframework.stereotype.Component;
+
+import hello.advanced.trace.TraceId;
+import hello.advanced.trace.TraceStatus;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class HelloTraceV1 {
+
+	private static final String START_PREFIX = "-->";
+	private static final String COMPLETE_PREFIX = "<--";
+	private static final String EX_PREFIX = "<X-";
+	public TraceStatus begin(String message) {
+		TraceId traceId = new TraceId();
+		Long startTimeMs = System.currentTimeMillis();
+		log.info("[{}] {}{}", traceId.getId(), addSpace(START_PREFIX,
+			traceId.getLevel()), message);
+		return new TraceStatus(traceId, startTimeMs, message);
+	}
+	public void end(TraceStatus status) {
+		complete(status, null);
+	}
+	public void exception(TraceStatus status, Exception e) {
+		complete(status, e);
+	}
+	private void complete(TraceStatus status, Exception e) {
+		Long stopTimeMs = System.currentTimeMillis();
+		long resultTimeMs = stopTimeMs - status.getStartTimeMs();
+		TraceId traceId = status.getTraceId();
+		if (e == null) {
+			log.info("[{}] {}{} time={}ms", traceId.getId(),
+				addSpace(COMPLETE_PREFIX, traceId.getLevel()), status.getMessage(),
+				resultTimeMs);
+		} else {
+			log.info("[{}] {}{} time={}ms ex={}", traceId.getId(),
+				addSpace(EX_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs,
+				e.toString());
+		} }
+	private static String addSpace(String prefix, int level) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < level; i++) {
+			sb.append( (i == level - 1) ? "|" + prefix : "|   ");
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/hello/advanced/trace/hellotrace/HelloTraceV2.java
+++ b/src/main/java/hello/advanced/trace/hellotrace/HelloTraceV2.java
@@ -1,0 +1,58 @@
+package hello.advanced.trace.hellotrace;
+
+import org.springframework.stereotype.Component;
+
+import hello.advanced.trace.TraceId;
+import hello.advanced.trace.TraceStatus;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class HelloTraceV2 {
+
+	private static final String START_PREFIX = "-->";
+	private static final String COMPLETE_PREFIX = "<--";
+	private static final String EX_PREFIX = "<X-";
+	public TraceStatus begin(String message) {
+		TraceId traceId = new TraceId();
+		Long startTimeMs = System.currentTimeMillis();
+		log.info("[{}] {}{}", traceId.getId(), addSpace(START_PREFIX,
+			traceId.getLevel()), message);
+		return new TraceStatus(traceId, startTimeMs, message);
+	}
+
+	public TraceStatus beginSync(TraceId beforeTraceId, String message) {
+		TraceId nextId = beforeTraceId.createNextId();
+		Long startTimeMs = System.currentTimeMillis();
+		log.info("[{}] {}{}", nextId.getId(), addSpace(START_PREFIX,
+			nextId.getLevel()), message);
+		return new TraceStatus(nextId, startTimeMs, message);
+	}
+
+	public void end(TraceStatus status) {
+		complete(status, null);
+	}
+	public void exception(TraceStatus status, Exception e) {
+		complete(status, e);
+	}
+	private void complete(TraceStatus status, Exception e) {
+		Long stopTimeMs = System.currentTimeMillis();
+		long resultTimeMs = stopTimeMs - status.getStartTimeMs();
+		TraceId traceId = status.getTraceId();
+		if (e == null) {
+			log.info("[{}] {}{} time={}ms", traceId.getId(),
+				addSpace(COMPLETE_PREFIX, traceId.getLevel()), status.getMessage(),
+				resultTimeMs);
+		} else {
+			log.info("[{}] {}{} time={}ms ex={}", traceId.getId(),
+				addSpace(EX_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs,
+				e.toString());
+		} }
+	private static String addSpace(String prefix, int level) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < level; i++) {
+			sb.append( (i == level - 1) ? "|" + prefix : "|   ");
+		}
+		return sb.toString();
+	}
+}

--- a/src/test/java/hello/advanced/trace/hellotrace/HelloTraceV1Test.java
+++ b/src/test/java/hello/advanced/trace/hellotrace/HelloTraceV1Test.java
@@ -1,0 +1,23 @@
+package hello.advanced.trace.hellotrace;
+
+import org.junit.jupiter.api.Test;
+
+import hello.advanced.trace.TraceStatus;
+
+public class HelloTraceV1Test {
+
+	@Test
+	void begin_end() {
+		HelloTraceV1 traceV1 = new HelloTraceV1();
+		TraceStatus status = traceV1.begin("hello");
+		traceV1.end(status);
+	}
+
+	@Test
+	void begin_exception() {
+		HelloTraceV1 traceV1 = new HelloTraceV1();
+		TraceStatus status = traceV1.begin("hello");
+		traceV1.exception(status, new IllegalStateException());
+
+	}
+}

--- a/src/test/java/hello/advanced/trace/hellotrace/HelloTraceV2Test.java
+++ b/src/test/java/hello/advanced/trace/hellotrace/HelloTraceV2Test.java
@@ -1,0 +1,27 @@
+package hello.advanced.trace.hellotrace;
+
+import org.junit.jupiter.api.Test;
+
+import hello.advanced.trace.TraceStatus;
+
+public class HelloTraceV2Test {
+
+	@Test
+	void begin_end() {
+		HelloTraceV2 traceV2 = new HelloTraceV2();
+		TraceStatus status1 = traceV2.begin("hello");
+		TraceStatus status2 = traceV2.beginSync(status1.getTraceId(), "hello2");
+		traceV2.end(status2);
+		traceV2.end(status1);
+	}
+
+	@Test
+	void begin_exception() {
+		HelloTraceV2 traceV2 = new HelloTraceV2();
+		TraceStatus status1 = traceV2.begin("hello");
+		TraceStatus status2 = traceV2.beginSync(status1.getTraceId(),"hello");
+		traceV2.exception(status2, new IllegalStateException());
+		traceV2.exception(status1, new IllegalStateException());
+
+	}
+}


### PR DESCRIPTION
- #1  로그 추적기 개발

## 로그 추적기 V1
로그 추적기는 `TraceId` 클래스로  요청한 `Thread` 의 아이디와 현재 `depth` 를 표현하며,
`TraceStatus`를 사용하여 현재 `TraceId` 의 상태를 저장하여 로그의 흐름을 이어 갈 수 있게 합니다.

`HelloTrace' 는 로그를 기록하는 역할을 하며, 요청,응답을 보기 편하게 하기 위해 "-->" , "<--" 를  prefix 로 설정하여
각 상황에 맞게 prefix 가 찍히도록 설정하였습니다.
로그의 형태는 "[TraceId] {prefix} {message}" 로 설정하여 TraceId 의 흐름을 볼 수 있도록 하였습니다.
각 로직에서의 실행 시간을 알기 위하여 시간을 추가하였습니다.

또한 예외가 발생 했을 경우 "<X-" 를 prefix 로 추가하였으며, 예외 발생시 로그를 출력하고자 서비스 로직의 흐름을 변경하는 것은 안되기 떄문에`throw` 로 서블릿으로 던지도록 하였습니다.

## 문제점
`traceId`의 상태 정보를 각 레이어에서 유지 할 수 없어서, 현재 depth 가 맞지않게 출력 되고, TraceId 의 id 또한 다르게 출력되는 문제가 있었습니다

## 로그 추적기 V2

현재 상태를 동기화 할 수 있는 `HelloTrace` 에 `beginSync` 로 동기화를 추가하였습니다. 
`TraceStatus`를 파라미터로 받아 상태를 동기화 시키도록 했습니다.

## 문제점

동기화에 성공하여 원하는 대로 출력은 되었지만, 로그 설정을 각 레이어에서 `TraceStatus` 를 파라미터로 추가해야하는 문제가 발생했습니다. 

---

Section 1 에서는 Logging 작업을 위해 요구사항을 개발하는 섹션이며, 크게 특이한 내용은 없어 정리는 따로 하지 않습니다.